### PR TITLE
Center align dates on mobile and remove position fixed on footer

### DIFF
--- a/style.css
+++ b/style.css
@@ -39,12 +39,14 @@ h2#date {
   font-weight: normal;
   font-family: monospace;
   margin: 0;
+  text-align: center;
 }
 
 img#logo {
   width: 18em;
   margin: 6em;
   margin-bottom: 1em;
+  margin-top: 0;
 }
 
 div#content {
@@ -58,7 +60,7 @@ p#cta-message {
   text-align: center;
   font-size: 1.5em;
   font-weight: bold;
-  margin: 4em 0 2em;
+  margin: 2em 0 2em;
 }
 
 form#mc-embedded-subscribe-form div.mc-field-group {
@@ -93,9 +95,9 @@ form#mc-embedded-subscribe-form div.mc-field-group input#mc-embedded-subscribe {
 }
 
 div#footer {
-  position: fixed;
   bottom: 0;
-  height: 5em;
+  margin-top: 1em;
+  margin-bottom: 1em;
   display: flex;
   width: 100%;
   justify-content: center;
@@ -112,6 +114,7 @@ div#footer a {
     width: 12em;
     margin: 2em;
     margin-bottom: 1em;
+    margin-top: 1em;
   }
 
   h1#title {
@@ -121,11 +124,12 @@ div#footer a {
 
   h2#date {
     margin-top: 0.5em;
+    max-width: 300px;
   }
 
   p#cta-message {
     font-size: 1.25em;
-    margin: 2.5em 0 2em;
+    margin: 1.5em 0 1.5em;
   }
 
   form#mc-embedded-subscribe-form div.mc-field-group input#mce-EMAIL {


### PR DESCRIPTION
Currently the [dates are not centered on mobile](https://user-images.githubusercontent.com/19913716/127750421-fd24ce93-b4a3-4764-8489-2cbcfa2c30b2.png) and the `position: fixed` footer can [overlap with the email subscribe input](https://user-images.githubusercontent.com/19913716/127750420-624fa434-a81b-428a-9e3d-93ce7783d0d2.png) on desktop.

I've attempted to fix both of these issues. Below is a collection of screenshots of the new layout at different screen sizes. If anyone has suggestions for how to improve this, I'm all ears.

**small phones (e.g. iPhone SE)**
<img width="379" alt="Screen Shot 2021-07-31 at 3 17 47 PM" src="https://user-images.githubusercontent.com/19913716/127750332-e5eaced5-7c43-4b5e-be74-9c095f533f92.png">

**normal sized phones (e.g. iPhone X)**
<img width="442" alt="Screen Shot 2021-07-31 at 3 17 41 PM" src="https://user-images.githubusercontent.com/19913716/127750335-770f99f8-1e4a-4f49-abb1-94f20a41ff94.png">

**tablet**
<img width="1084" alt="Screen Shot 2021-07-31 at 3 17 35 PM" src="https://user-images.githubusercontent.com/19913716/127750336-0aa43a45-9c3d-4e13-90fe-6706234da29a.png">

**laptop**
<img width="1206" alt="Screen Shot 2021-07-31 at 3 17 28 PM" src="https://user-images.githubusercontent.com/19913716/127750338-b8365415-03d9-4602-b012-e2756b64f643.png">


